### PR TITLE
Update Go Docker images to 1.18

### DIFF
--- a/basil-build/Dockerfile
+++ b/basil-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18
 
 LABEL repository="https://github.com/gardenbed/actions"
 LABEL maintainer="Milad Irannejad <moorara@users.noreply.github.com>"

--- a/go-cover/Dockerfile
+++ b/go-cover/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18
 
 LABEL repository="https://github.com/gardenbed/actions"
 LABEL maintainer="Milad Irannejad <moorara@users.noreply.github.com>"

--- a/go-lint/Dockerfile
+++ b/go-lint/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18
 
 LABEL repository="https://github.com/gardenbed/actions"
 LABEL maintainer="Milad Irannejad <moorara@users.noreply.github.com>"


### PR DESCRIPTION
## Description

  - [x] Update Go Docker images

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [ ] Tests are provided for the new change
