### PR TITLE
go-lint action lints the complete source code by default

### DIFF
--- a/go-lint/action.yaml
+++ b/go-lint/action.yaml
@@ -9,11 +9,10 @@ inputs:
   timeout:
     description: The total timeout.
     required: false
-    default: 2m
+    default: 5m
   from_revision:
     description: If specified, only the changes since this git revision will be considered.
     required: false
-    default: origin/main
 runs:
   using: docker
   image: Dockerfile


### PR DESCRIPTION
## Description

`go-lint` now lints the entire source code in the given path by default. If you want to only lint the diff, set the `from_revision` input parameter.

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Tests are provided for the new change
