### PR TITLE
Remove deprecated set-output command

### DIFF
--- a/go-cover/entrypoint.sh
+++ b/go-cover/entrypoint.sh
@@ -29,5 +29,5 @@ exit_code=$?
 go tool cover -html=c.out -o coverage.html
 
 # Set action output parameters
-echo "::set-output name=coverage_profile_file::c.out"
-echo "::set-output name=coverage_report_file::coverage.html"
+echo "coverage_profile_file=c.out" >> $GITHUB_OUTPUT
+echo "coverage_report_file=coverage.html" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

### Checklist

  - [x] PR title is clear and describes the change
  - [x] Commit messages are self-explanatory and summarize the change
  - [ ] Tests are provided for the new change
